### PR TITLE
Name the two samples Korpus I and Korpus II consistently

### DIFF
--- a/corpus_analysis/corpus-analysis_analysis.md
+++ b/corpus_analysis/corpus-analysis_analysis.md
@@ -117,7 +117,7 @@ Als Resultat erhalten wir pro Korpus 400 Datenpunkte, für jeden Text einen, die
 
 Auf einem Streudiagramm lassen sich allerdings nicht sofort Entwicklungen ablesen. Um diesen Nachteil beizukommen, lässt sich mittels linearer Regression eine **Regressionsgerade** oder sogenannte Trend-Linie berechnen. Die Trend-Linie soll die Datenpunkte möglichst gut beschreiben, das heißt, sie soll möglichst nah an allen Punkten vorbeilaufen. Je nachdem, ob die Gerade steigt oder fällt, ist eine Zu- oder Abnahme des semantischen Felds Luft zu erkennen.
 
-In folgendem Beispiel wurden vier Texte aus Korpus I ausgewählt, für die die relative Häufigkeit und die Trend-Linie errechnet wurde.
+In folgendem Beispiel wurden vier Texte aus Korpus I (der ersten unserer beiden Stichproben, siehe [Sampling und Filterung des Korpus](../corpus_collection/corpus-collection_filtering-our-corpus.ipynb)) ausgewählt, für die die relative Häufigkeit und die Trend-Linie errechnet wurde.
 
 `````{admonition} Mindestanzahl an Datenpunkten für eine generalisierbare Interpretation
 :class: caution

--- a/corpus_analysis/corpus-analysis_intro.md
+++ b/corpus_analysis/corpus-analysis_intro.md
@@ -29,6 +29,8 @@ Mit Ihren Rückmeldungen können wir unser interaktives Lehrbuch gezielt an Ihre
 
 Nachdem wir im vorherigen Kapitel zwei Korpora literarischer Texte automatisch mit linguistischen Informationen annotiert haben (siehe Kapitel [Korpusverarbeitung – Von Strings zu Token](corpus-processing_intro)), sind alle Vorverabeitungsschritte durchgeführt und wir wenden uns in diesem Kapitel der Korpusanalyse zu.
 
+Bei diesen beiden Korpora handelt es sich um die zwei Zufallsstichproben, die wir im Abschnitt [Sampling und Filterung des Korpus](../corpus_collection/corpus-collection_filtering-our-corpus.ipynb) gezogen und dort als **Korpus I** (Random State `42`) und **Korpus II** (Random State `31415`) benannt haben. Beide Korpora sind also zwei unabhängig gezogene Stichproben aus demselben gefilterten Quellkorpus. Sämtliche folgenden Analysen führen wir auf **beiden Korpora parallel** durch und vergleichen die Ergebnisse miteinander – so lässt sich einschätzen, welche Muster robust sind und welche stärker von der konkreten Zufallsauswahl abhängen.
+
 
 ```{figure} ../assets/images/flow-chart_corpus-analysis.png
 ---

--- a/corpus_analysis/corpus-analysis_semantic-field-analysis.ipynb
+++ b/corpus_analysis/corpus-analysis_semantic-field-analysis.ipynb
@@ -28,8 +28,10 @@
     "## Übersicht \n",
     "Im Folgenden werden die annotierten Dateien (CSV-Format) analysiert. Unser Ziel ist es, die Wort-/Lemma-Häufigkeiten des semantischen Felds \"Luft\" im Verlauf der Zeit zu analysieren und zu visualisieren, um festzustellen, ob es, parallel zur industriellen Revolution, einen Anstieg im Auftreten des Felds gibt. \n",
     "\n",
+    "Wir führen diese Analyse auf unseren beiden Korpora durch – **Korpus I** und **Korpus II**, den beiden Zufallsstichproben, die wir im Abschnitt [Sampling und Filterung des Korpus](../corpus_collection/corpus-collection_filtering-our-corpus.ipynb) gezogen haben. Beide Korpora werden parallel ausgewertet und die Ergebnisse anschließend miteinander verglichen, um die Robustheit der Befunde einzuschätzen.\n",
+    "\n",
     "Dafür werden folgendene Schritte durchgeführt:\n",
-    "1. Einlesen des Korpus, der Metadaten-Dateien für Korpora I und II und des semantischen Felds \"Luft\"\n",
+    "1. Einlesen des Korpus, der Metadaten-Dateien für Korpus I und II und des semantischen Felds \"Luft\"\n",
     "2. Extraktion der Worthäufigkeiten und Visualisieren der Worthäufigkeiten für Korpus I\n",
     "3. Extraktion der Worthäufigkeiten und Visualisieren der Worthäufigkeiten für Korpus II\n",
     "4. Diskussion der Ergebnisse"

--- a/corpus_analysis/corpus-analysis_syntactic-ngram.ipynb
+++ b/corpus_analysis/corpus-analysis_syntactic-ngram.ipynb
@@ -27,7 +27,7 @@
     "\n",
     "\n",
     "## Übersicht\n",
-    "Im Folgenden wird das Korpus mithilfe syntaktischer n-Gramme analysiert. Ziel ist es, wiederkehrende grammatische Muster, insbesondere adjektivische Modifikationen von Substantiven, im Verlauf der Zeit zu untersuchen und damit über rein lexikalische Häufigkeiten hinauszugehen. Im Unterschied zur Analyse semantischer Felder stehen hier syntaktisch motivierte Wortkombinationen auf Basis von Abhängigkeitsbeziehungen im Fokus, etwa *Adjektiv ← Substantiv*-Relationen wie „*verdorbene ← Luft*“, „*frischer ← Wind*“ oder „*dicker ← Qualm*“. Untersucht wird, wie häufig solche Konstruktionen im Korpus auftreten und wie sich ihr Vorkommen zeitlich entwickelt – um stilistische und diskursive Veränderungen in der Beschreibung bestimmter Konzepte sichtbar zu machen.\n",
+    "Im Folgenden werden unsere beiden Korpora – **Korpus I** und **Korpus II**, die beiden Zufallsstichproben aus dem Abschnitt [Sampling und Filterung des Korpus](../corpus_collection/corpus-collection_filtering-our-corpus.ipynb) – mithilfe syntaktischer n-Gramme analysiert. Wie schon in der semantischen Feldanalyse werten wir beide Korpora parallel aus und vergleichen die Ergebnisse, um einschätzen zu können, welche Muster robust sind und welche von der konkreten Zufallsauswahl abhängen. Ziel ist es, wiederkehrende grammatische Muster, insbesondere adjektivische Modifikationen von Substantiven, im Verlauf der Zeit zu untersuchen und damit über rein lexikalische Häufigkeiten hinauszugehen. Im Unterschied zur Analyse semantischer Felder stehen hier syntaktisch motivierte Wortkombinationen auf Basis von Abhängigkeitsbeziehungen im Fokus, etwa *Adjektiv ← Substantiv*-Relationen wie „*verdorbene ← Luft*“, „*frischer ← Wind*“ oder „*dicker ← Qualm*“. Untersucht wird, wie häufig solche Konstruktionen in den beiden Korpora auftreten und wie sich ihr Vorkommen zeitlich entwickelt – um stilistische und diskursive Veränderungen in der Beschreibung bestimmter Konzepte sichtbar zu machen.\n",
     "\n",
     "In diesem Notebook-Walkthrough beschränken wir uns aus Gründen der Übersichtlichkeit auf das Substantiv „Luft“, der Code funktioniert jedoch ebenso mit einer ganzen Liste mehrerer Substantive.\n",
     "\n",
@@ -360,9 +360,9 @@
     "\n",
     "### Zur Erinnerung: Zwei-Stichproben-Ansatz\n",
     "\n",
-    "Für die Robustheit der Analyse werden zwei verschiedene Stichproben (siehe [Abschnitt „Sampling und Filterung des Korpus“](../corpus_collection/corpus-collection_filtering-our-corpus.ipynb)) verwendet:\n",
-    "- **Sample 1**: Zufällige Auswahl von 50 Texten pro Jahrzehnt (random_state=42)\n",
-    "- **Sample 2**: Alternative Zufällige Auswahl von 50 Texten pro Jahrzehnt (random_state=31415)\n",
+    "Für die Robustheit der Analyse arbeiten wir mit zwei verschiedenen Stichproben (siehe [Abschnitt „Sampling und Filterung des Korpus“](../corpus_collection/corpus-collection_filtering-our-corpus.ipynb)) – unseren beiden Korpora:\n",
+    "- **Korpus I**: Zufällige Auswahl von 50 Texten pro Jahrzehnt (random_state=42)\n",
+    "- **Korpus II**: Alternative zufällige Auswahl von 50 Texten pro Jahrzehnt (random_state=31415)\n",
     "\n",
     "Dieser Ansatz ermöglicht es, zu überprüfen, ob die beobachteten Muster robust gegenüber unterschiedlichen Stichproben sind oder ob sie durch die spezifische Textauswahl beeinflusst werden."
    ]
@@ -397,7 +397,7 @@
    "id": "e4c8295d",
    "metadata": {},
    "source": [
-    "In der folgenden Zelle verwenden wir das Programm `wget`, um die Metadaten-Dateien für die beiden Samples aus dem GitHub-Repository der Fallstudie herunterzuladen und sie im dafür vorgesehenen Ordner abzulegen.\n"
+    "In der folgenden Zelle verwenden wir das Programm `wget`, um die Metadaten-Dateien für die beiden Korpora (Korpus I und Korpus II) aus dem GitHub-Repository der Fallstudie herunterzuladen und sie im dafür vorgesehenen Ordner abzulegen.\n"
    ]
   },
   {
@@ -433,7 +433,7 @@
    "id": "4f0e5e5a",
    "metadata": {},
    "source": [
-    "Stichprobe 1:"
+    "Korpus I:"
    ]
   },
   {
@@ -493,7 +493,7 @@
    "id": "bf8a334c",
    "metadata": {},
    "source": [
-    "Stichprobe 2:"
+    "Korpus II:"
    ]
   },
   {
@@ -747,7 +747,7 @@
    "id": "5d513419",
    "metadata": {},
    "source": [
-    "In der folgenden Zelle führen wir die zuvor definierte Funktion `extract_dependent_adjective_list` aus und extrahieren die vom ausgewählten Substantiv abhängigen Adjektive (aus dem Korpus „Stichprobe 1“). Wir erhalten eine Liste (einen DataFrame, `adj_df`), in der für jedes Buch die Häufigkeit derjenigen Adjektive aufgeführt ist, die in unserem Korpus gemeinsam mit dem Substantiv ein syntaktisches Bigramm bilden. Zudem erhalten wir eine Gesamtliste (`top_adjs`) der am häufigsten vorkommenden Adjektive dieser Art für das gesamte Korpus."
+    "In der folgenden Zelle führen wir die zuvor definierte Funktion `extract_dependent_adjective_list` aus und extrahieren die vom ausgewählten Substantiv abhängigen Adjektive (aus **Korpus I**). Wir erhalten eine Liste (einen DataFrame, `adj_df`), in der für jedes Buch die Häufigkeit derjenigen Adjektive aufgeführt ist, die in unserem Korpus gemeinsam mit dem Substantiv ein syntaktisches Bigramm bilden. Zudem erhalten wir eine Gesamtliste (`top_adjs`) der am häufigsten vorkommenden Adjektive dieser Art für das gesamte Korpus."
    ]
   },
   {
@@ -773,7 +773,7 @@
    "id": "94cc7027",
    "metadata": {},
    "source": [
-    "Nun führen wir denselben Vorgang für „Stichprobe 2“ durch."
+    "Nun führen wir denselben Vorgang für **Korpus II** durch."
    ]
   },
   {
@@ -815,7 +815,7 @@
    "id": "52b4ea9b",
    "metadata": {},
    "source": [
-    "Sample 1: "
+    "Korpus I: "
    ]
   },
   {
@@ -835,7 +835,7 @@
    "id": "79f34137",
    "metadata": {},
    "source": [
-    "Sample 2: "
+    "Korpus II: "
    ]
   },
   {
@@ -873,7 +873,7 @@
    "id": "8a58fd4a",
    "metadata": {},
    "source": [
-    "Sample 1: "
+    "Korpus I: "
    ]
   },
   {
@@ -891,7 +891,7 @@
    "id": "db234cb5",
    "metadata": {},
    "source": [
-    "Sample 2: "
+    "Korpus II: "
    ]
   },
   {
@@ -1199,7 +1199,7 @@
     "tags": []
    },
    "source": [
-    "#### Sample 1:"
+    "#### Korpus I:"
    ]
   },
   {
@@ -1245,7 +1245,7 @@
     "tags": []
    },
    "source": [
-    "#### Sample 2:"
+    "#### Korpus II:"
    ]
   },
   {
@@ -1534,7 +1534,7 @@
     "tags": []
    },
    "source": [
-    "#### Sample 1"
+    "#### Korpus I"
    ]
   },
   {
@@ -1567,7 +1567,7 @@
     "tags": []
    },
    "source": [
-    "#### Sample 2:"
+    "#### Korpus II:"
    ]
   },
   {
@@ -1908,7 +1908,7 @@
     "tags": []
    },
    "source": [
-    "Die folgende Tabelle listet die identifizierten Ausreißertexte für die jeweiligen Adjektiv–Nomen-Konstruktionen auf, also jene Werke, die maßgeblich zu den beobachteten Ausschlägen in den Zeitreihen beitragen (in Sample 1)."
+    "Die folgende Tabelle listet die identifizierten Ausreißertexte für die jeweiligen Adjektiv–Nomen-Konstruktionen auf, also jene Werke, die maßgeblich zu den beobachteten Ausschlägen in den Zeitreihen beitragen (in Korpus I)."
    ]
   },
   {
@@ -2054,7 +2054,7 @@
     "tags": []
    },
    "source": [
-    "Die folgende Tabelle listet die identifizierten Ausreißertexte für die jeweiligen Adjektiv–Nomen-Konstruktionen auf, also jene Werke, die maßgeblich zu den beobachteten Ausschlägen in den Zeitreihen beitragen (in Sample 2)."
+    "Die folgende Tabelle listet die identifizierten Ausreißertexte für die jeweiligen Adjektiv–Nomen-Konstruktionen auf, also jene Werke, die maßgeblich zu den beobachteten Ausschlägen in den Zeitreihen beitragen (in Korpus II)."
    ]
   },
   {

--- a/corpus_collection/corpus-collection_filtering-our-corpus.ipynb
+++ b/corpus_collection/corpus-collection_filtering-our-corpus.ipynb
@@ -419,7 +419,9 @@
     "\n",
     "Wir ziehen hier bewusst zwei Stichproben mit unterschiedlichen Random States (`42` und `31415`). Die konkreten Zahlen sind dabei beliebig gewählt – entscheidend ist nur, dass sie festgelegt sind, damit die jeweilige Stichprobe reproduzierbar bleibt.\n",
     "\n",
-    "Beide Stichproben werden in den folgenden Analysekapiteln (semantische Feldanalyse, syntaktische N-Gramm-Analyse) parallel ausgewertet: Die Analysen werden also auf beiden Stichproben unabhängig durchgeführt, und die Ergebnisse werden anschließend miteinander verglichen. So können wir beurteilen, welche Muster sich in beiden Stichproben zeigen (und damit als robust gelten dürfen) und welche stärker von der konkreten Zufallsauswahl abhängen."
+    "Diese beiden Stichproben bezeichnen wir im Folgenden durchgängig als **Korpus I** (Random State `42`) und **Korpus II** (Random State `31415`). Jede der beiden Stichproben ist dabei selbst ein vollständiges Arbeitskorpus, das wir in den Analysekapiteln auswerten – daher die Bezeichnung als „Korpus\". Wo immer in den folgenden Kapiteln von **Korpus I** und **Korpus II** die Rede ist, sind genau diese beiden hier gezogenen Stichproben gemeint.\n",
+    "\n",
+    "Beide Korpora (Korpus I und Korpus II) werden in den folgenden Analysekapiteln (semantische Feldanalyse, syntaktische N-Gramm-Analyse) parallel ausgewertet: Die Analysen werden also auf beiden Stichproben unabhängig durchgeführt, und die Ergebnisse werden anschließend miteinander verglichen. So können wir beurteilen, welche Muster sich in beiden Stichproben zeigen (und damit als robust gelten dürfen) und welche stärker von der konkreten Zufallsauswahl abhängen."
    ]
   },
   {
@@ -484,7 +486,7 @@
     "tags": []
    },
    "source": [
-    "Zur Kontrolle visualisieren wir die gezogene Stichprobe (`subset_decades`) pro Jahrzehnt. Anders als im ungefilterten Korpus sind die Balken nun über alle Jahrzehnte hinweg annähernd gleich hoch (jeweils bis zu 50 Texte) – die Stichprobe ist also entlang der Zeitachse gleichgewichtet."
+    "Zur Kontrolle visualisieren wir die gezogene Stichprobe (`subset_decades`, unser **Korpus I**) pro Jahrzehnt. Anders als im ungefilterten Korpus sind die Balken nun über alle Jahrzehnte hinweg annähernd gleich hoch (jeweils bis zu 50 Texte) – die Stichprobe ist also entlang der Zeitachse gleichgewichtet."
    ]
   },
   {
@@ -538,9 +540,9 @@
     "tags": []
    },
    "source": [
-    "## Erstellung der alternativen Stichprobe mit unterschiedlichem Zufallszustand\n",
+    "## Erstellung der alternativen Stichprobe (Korpus II) mit unterschiedlichem Zufallszustand\n",
     "\n",
-    "Wir wiederholen die Ziehung nun mit einem zweiten Random State (`31415`) und erhalten so eine alternative, unabhängig gezogene Stichprobe. Sie enthält ebenfalls bis zu 50 Texte pro Jahrzehnt und dient später als Vergleichsmaßstab, um zu prüfen, ob unsere Ergebnisse von der konkreten Zufallsauswahl abhängen."
+    "Wir wiederholen die Ziehung nun mit einem zweiten Random State (`31415`) und erhalten so eine alternative, unabhängig gezogene Stichprobe – unser **Korpus II**. Sie enthält ebenfalls bis zu 50 Texte pro Jahrzehnt und dient später als Vergleichsmaßstab, um zu prüfen, ob unsere Ergebnisse von der konkreten Zufallsauswahl abhängen."
    ]
   },
   {
@@ -569,7 +571,7 @@
    "id": "0584a889",
    "metadata": {},
    "source": [
-    "Dieselbe Kontrolle nehmen wir für die alternative Stichprobe (`subset_decades_alt`) vor – auch sie ist mit bis zu 50 Texten pro Jahrzehnt gleichmäßig über die Zeit verteilt."
+    "Dieselbe Kontrolle nehmen wir für die alternative Stichprobe (`subset_decades_alt`, unser **Korpus II**) vor – auch sie ist mit bis zu 50 Texten pro Jahrzehnt gleichmäßig über die Zeit verteilt."
    ]
   },
   {
@@ -677,9 +679,9 @@
     "\n",
     "overlap_df = pd.DataFrame.from_records(records).sort_values(\"decade\").reset_index(drop=True)\n",
     "\n",
-    "print(f\"Texte in Stichprobe 1 (subset_decades):     {len(subset_decades)}\")\n",
-    "print(f\"Texte in Stichprobe 2 (subset_decades_alt): {len(subset_decades_alt)}\")\n",
-    "print(f\"Überlappung über alle Jahrzehnte:           {len(ids & ids_alt)}\")\n",
+    "print(f\"Texte in Korpus I (subset_decades):      {len(subset_decades)}\")\n",
+    "print(f\"Texte in Korpus II (subset_decades_alt): {len(subset_decades_alt)}\")\n",
+    "print(f\"Überlappung über alle Jahrzehnte:        {len(ids & ids_alt)}\")\n",
     "overlap_df\n"
    ]
   },
@@ -703,9 +705,9 @@
     ")\n",
     "\n",
     "label_map = {\n",
-    "    \"in_both\": \"in beiden Stichproben\",\n",
-    "    \"only_sample_1\": \"nur in Stichprobe 1\",\n",
-    "    \"only_sample_2\": \"nur in Stichprobe 2\",\n",
+    "    \"in_both\": \"in beiden Korpora\",\n",
+    "    \"only_sample_1\": \"nur in Korpus I\",\n",
+    "    \"only_sample_2\": \"nur in Korpus II\",\n",
     "}\n",
     "plot_long[\"kategorie\"] = plot_long[\"kategorie\"].map(label_map)\n",
     "\n",
@@ -714,13 +716,13 @@
     "    x=\"decade\",\n",
     "    y=\"anzahl\",\n",
     "    color=\"kategorie\",\n",
-    "    title=\"Überlappung der beiden Stichproben pro Jahrzehnt\",\n",
+    "    title=\"Überlappung von Korpus I und Korpus II pro Jahrzehnt\",\n",
     "    labels={\"decade\": \"Jahrzehnt\", \"anzahl\": \"Anzahl Texte\", \"kategorie\": \"Kategorie\"},\n",
     "    category_orders={\n",
     "        \"kategorie\": [\n",
-    "            \"in beiden Stichproben\",\n",
-    "            \"nur in Stichprobe 1\",\n",
-    "            \"nur in Stichprobe 2\",\n",
+    "            \"in beiden Korpora\",\n",
+    "            \"nur in Korpus I\",\n",
+    "            \"nur in Korpus II\",\n",
     "        ]\n",
     "    },\n",
     "    hover_data={\"pool_size\": True},\n",
@@ -760,9 +762,9 @@
    "source": [
     "## Zusammenfassung: unser Forschungskorpus\n",
     "\n",
-    "Mit den oben durchgeführten Schritten haben wir aus dem *Corpus of German-Language Fiction* zwei zeitlich gleichgewichtete Stichproben extrahiert. Jede Stichprobe enthält bis zu 50 zufällig ausgewählte Texte pro Jahrzehnt für die Jahrzehnte 1810er bis 1890er.\n",
+    "Mit den oben durchgeführten Schritten haben wir aus dem *Corpus of German-Language Fiction* zwei zeitlich gleichgewichtete Stichproben extrahiert – **Korpus I** (Random State `42`) und **Korpus II** (Random State `31415`). Jede Stichprobe enthält bis zu 50 zufällig ausgewählte Texte pro Jahrzehnt für die Jahrzehnte 1810er bis 1890er.\n",
     "\n",
-    "**Diese beiden Stichproben bilden den Untersuchungsgegenstand für den Rest dieser Fallstudie.** Sie werden als CSV-Dateien gespeichert und in den folgenden Kapiteln (Korpusverarbeitung, semantische Feldanalyse, syntaktische N-Gramm-Analyse) parallel weiterverarbeitet. Wo immer wir später ein Ergebnis berichten, beziehen wir uns also auf zwei unabhängige Auswertungen desselben Verfahrens auf zwei unterschiedlichen Zufallsstichproben aus demselben gefilterten Korpus. Die beiden Auswertungen lassen sich vergleichen, um die Robustheit der Befunde gegenüber der konkreten Zufallsauswahl einzuschätzen.\n"
+    "**Diese beiden Stichproben – Korpus I und Korpus II – bilden den Untersuchungsgegenstand für den Rest dieser Fallstudie.** Sie werden als CSV-Dateien gespeichert und in den folgenden Kapiteln (Korpusverarbeitung, semantische Feldanalyse, syntaktische N-Gramm-Analyse) parallel weiterverarbeitet. Wo immer wir später ein Ergebnis berichten, beziehen wir uns also auf zwei unabhängige Auswertungen desselben Verfahrens auf zwei unterschiedlichen Zufallsstichproben aus demselben gefilterten Korpus. Die beiden Auswertungen lassen sich vergleichen, um die Robustheit der Befunde gegenüber der konkreten Zufallsauswahl einzuschätzen.\n"
    ]
   }
  ],


### PR DESCRIPTION
The two random samples (random_state 42 and 31415) were referred to inconsistently across the materials — "Stichprobe 1/2" where they are created, "Korpus I/II" in the semantic-field analysis, and a singular "das Korpus" plus "Sample 1/2" in the syntactic n-gram notebook — and were never named at the point where they are drawn.

Introduce the names Korpus I (random_state 42) and Korpus II (random_state 31415) once in the filtering notebook, remind the reader of them at the start of the analysis chapter, and use them consistently for every per-entity reference downstream (headings, table captions, plot labels). The methodological term "Stichprobe" is kept where it describes the sampling itself. Python variable names and CSV filenames are left unchanged.

Fixes #97
Fixes #131